### PR TITLE
Add possibility to select desired browser from an environment variable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+ ** 0.02 / 2016-08-26
+  - Add the possibility to use an environment variable for desired browser
 
  ** 0.01 / 2016-06-??
   - Initial release to replace LedgerSMB's

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name     = Weasel-Driver-Selenium2
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
-version  = 0.01
+version  = 0.02
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel/Driver/Selenium2.pm

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -129,6 +129,8 @@ sub implements {
 
 sub start {
     my $self = shift;
+    my $browser = $self->{caps}{browser_name} =~ /\$\{([^\}]+)\}/;
+    $self->{caps}{browser_name} = $ENV{$1} if $browser;
     my $driver = Selenium::Remote::Driver->new(%{$self->caps});
 
     $self->_driver($driver);


### PR DESCRIPTION
Define environment variable to select broser to run tests. If the variable is undefined, selenium will use default value.
If no variable is used, selenium will use the browser_name value in capabilities.