### PR TITLE
Allow remote headless browser and get page source as seen by the driver

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+ ** 0.03 / 2016-09-01
+  - Extend the possibility to use an environment variable to others capabilities,
+    such as remote_server_addr, platform and version.
+  - Fix documented port
+  - Add possibility to get page source seen by the driver.
+
  ** 0.02 / 2016-08-26
   - Add the possibility to use an environment variable for desired browser
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name     = Weasel-Driver-Selenium2
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
-version  = 0.02
+version  = 0.03
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel/Driver/Selenium2.pm

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -134,9 +134,11 @@ sub start {
     my $self = shift;
 
     do {
-        my $capability_name = $_;
-        my $capability = $self->{caps}{$capability_name} =~ /\$\{([^\}]+)\}/;
-        $self->{caps}{$capability_name} = $ENV{$1} if $capability;
+        if ( defined  $self->{caps}{$_}) {
+            my $capability_name = $_;
+            my $capability = $self->{caps}{$capability_name} =~ /\$\{([^\}]+)\}/;
+            $self->{caps}{$capability_name} = $ENV{$1} if $capability;
+        }
     } for (qw/browser_name remote_server_addr version platform/);
 
     my $driver = Selenium::Remote::Driver->new(%{$self->caps});

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -17,7 +17,7 @@ Weasel::Driver::Selenium2 - Weasel driver wrapping Selenium::Remote::Driver
     wait_timeout => 3000,    # 3000 msec == 3s
     window_size => '1024x1280',
     caps => {
-      port => 4443,
+      port => 4444,
       # ... and other Selenium::Remote::Driver capabilities options
     },
   );
@@ -125,12 +125,20 @@ sub implements {
 
 =item start
 
+A few capabilities can be specified in t/.pherkin.yaml
+Some can even be specified as environment variables, they will be expanded here if present.
+
 =cut
 
 sub start {
     my $self = shift;
-    my $browser = $self->{caps}{browser_name} =~ /\$\{([^\}]+)\}/;
-    $self->{caps}{browser_name} = $ENV{$1} if $browser;
+
+    do {
+        my $capability_name = $_;
+        my $capability = $self->{caps}{$capability_name} =~ /\$\{([^\}]+)\}/;
+        $self->{caps}{$capability_name} = $ENV{$1} if $capability;
+    } for (qw/browser_name remote_server_addr version platform/);
+
     my $driver = Selenium::Remote::Driver->new(%{$self->caps});
 
     $self->_driver($driver);
@@ -300,6 +308,16 @@ sub set_selected {
     # The other solution is to use is_selected to verify the current state
     # and toggling by click()ing
     $self->_resolve_id($id)->set_selected($value);
+}
+
+=item get_page_source($fh)
+
+=cut
+
+sub get_page_source {
+    my ($self) = @_;
+
+    return $self->_driver->get_page_source();
 }
 
 =item screenshot($fh)


### PR DESCRIPTION
Add environment variable substitution possibility for a few capabilities
Add possibility to get page source seen by the driver
Fix default documented port.
Push version to 0.03 and document changes.