### PR TITLE
Force compatibility with JSONWIRE for new FF & Chrome

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+** 0.10 / 2019-07-01
+   - Force compatibility with JSONWIRE for new FF & Chrome
+     get_attribute won't try to separate attribute and properties
+
 ** 0.09 / 2019-06-25
    - Use high-resolution timings from Time::HiRes by actually
      importing time() and sleep()

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Weasel::Driver::Selenium2 - Selenium::Remote::Driver wrapper for Weasel
 
 # VERSION
 
-0.09
+0.10
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name     = Weasel-Driver-Selenium2
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
-version  = 0.09
+version  = 0.10
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel/Driver/Selenium2.pm

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -5,7 +5,7 @@ Weasel::Driver::Selenium2 - Weasel driver wrapping Selenium::Remote::Driver
 
 =head1 VERSION
 
-0.09
+0.10
 
 =head1 SYNOPSIS
 
@@ -291,7 +291,7 @@ sub execute_script {
 sub get_attribute {
     my ($self, $id, $att) = @_;
 
-    return $self->_resolve_id($id)->get_attribute($att);
+    return $self->_resolve_id($id)->get_attribute($att,1);
 }
 
 =item get_page_source($fh)


### PR DESCRIPTION
Force newer FIrefox to stay JSONWIRE compatible until Weasel support the WebDriver protocol