### PR TITLE
Make scroll compatible with chrome and opera

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+** 0.11 / 2020-06-17
+   - Fix a bug with scrolling an element into the viewport on Chrome & Opera
+
 ** 0.10 / 2019-08-10
    - Force compatibility with JSONWIRE for new FF & Chrome
      get_attribute won't try to separate attribute and properties

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -64,7 +64,7 @@ use English qw(-no_match_vars);
 use Moose;
 with 'Weasel::DriverRole';
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 
 =head1 ATTRIBUTES
@@ -463,7 +463,11 @@ sub _resolve_id {
 sub _scroll {
     my ($self, $id) = @_;
 
-    $self->_driver->execute_script('arguments[0].scrollIntoView(true);',
+    $self->_driver->execute_script('arguments[0].scrollIntoView('
+                                 + '{block: "center", '
+                                 +  'inline: "center", '
+                                 +  'behavior: "smooth"'
+                                 + '});',
                                    $id);
     return $id;
 }
@@ -512,4 +516,3 @@ Licensed under the same terms as Perl.
 =cut
 
 1;
-


### PR DESCRIPTION
Make sure that the scroll routine position the desired field in the middle of the viewport instead of the top to fix visibility issues