### PR TITLE
Properly fix JSONWIRE compatibility on Firefox

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+** 0.13 / 2021-04-02
+   - Properly fix JSONWIRE compatibility with FF by letting
+     get_attribute try to separate attributes and properties on browsers
+     which allows it and fallback on attributes only on failure.
+
 ** 0.12 / 2021-04-01
    - Move Continuous Integration tests to Github Actions
 

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -299,10 +299,10 @@ sub get_attribute {
 
     my $element = $self->_resolve_id($id);
     my $value;
-    $value = $element ->get_attribute($att)  # Try with property/attribute
+    $value = $element->get_attribute($att)  # Try with property/attribute
         if $self->_driver->{is_wd3};
     return $value
-        // $element ->get_attribute($att,1); # Force using attribute
+        // $element->get_attribute($att,1); # Force using attribute
 }
 
 =item get_page_source($fh)

--- a/lib/Weasel/Driver/Selenium2.pm
+++ b/lib/Weasel/Driver/Selenium2.pm
@@ -5,7 +5,7 @@ Weasel::Driver::Selenium2 - Weasel driver wrapping Selenium::Remote::Driver
 
 =head1 VERSION
 
-0.11
+0.13
 
 =head1 SYNOPSIS
 
@@ -64,7 +64,7 @@ use English qw(-no_match_vars);
 use Moose;
 with 'Weasel::DriverRole';
 
-our $VERSION = '0.11';
+our $VERSION = '0.13';
 
 
 =head1 ATTRIBUTES
@@ -297,7 +297,12 @@ sub execute_script {
 sub get_attribute {
     my ($self, $id, $att) = @_;
 
-    return $self->_resolve_id($id)->get_attribute($att,1);
+    my $element = $self->_resolve_id($id);
+    my $value;
+    $value = $element ->get_attribute($att)  # Try with property/attribute
+        if $self->_driver->{is_wd3};
+    return $value
+        // $element ->get_attribute($att,1); # Force using attribute
 }
 
 =item get_page_source($fh)


### PR DESCRIPTION
This PR completes #13 with Firefox and allows tests to try to get a property for browsers which supports it and fallback to getting attributes on failure  or not supported.